### PR TITLE
Add support for home games; emailed hand requiests and GBP

### DIFF
--- a/src/pet/hp/GameUtil.java
+++ b/src/pet/hp/GameUtil.java
@@ -45,6 +45,8 @@ public class GameUtil {
 				return "USD";
 			case '€': 
 				return "EUR";
+			case '£':
+				return "GBP";
 			case Game.PLAY_CURRENCY: 
 				return "Play";
 			case Game.TOURN_CURRENCY:

--- a/src/pet/hp/impl/PSHandRE.java
+++ b/src/pet/hp/impl/PSHandRE.java
@@ -8,14 +8,15 @@ class PSHandRE {
 	// PokerStars Hand #84393778794:  7 Card Stud Limit (20/40) - 2012/08/07 4:39:16 ET
 	// PokerStars Hand #79306750218:  Triple Stud (7 Card Stud Limit, 4/8) - 2012/04/23 5:55:37 UTC [2012/04/23 1:55:37 ET]
 	// PokerStars Hand #83338296941:  8-Game (Razz Limit, 100/200) - 2012/07/15 1:45:25 ET
-	static final Pattern pat = Pattern.compile("PokerStars (?:(Zoom) )?(?:Hand|Game) (\\d+) "
-			+ "(?:Tournament (\\d+) (?:(Freeroll)|(\\S+?)\\+(\\S+?)(?: (USD))?) )?" 
+	// PokerStars Home Game Hand #212631111111: {Club #3311111} Tournament #2871111111, £5.00+£0.50 GBP Hold'em No Limit - Level I (15/30) - 2020/01/01 01:01:01 WET [2020/01/01 01:01:01 ET]
+	static final Pattern pat = Pattern.compile("PokerStars (?:(Home Game) )(?:(Zoom) )?(?:Hand|Game) (\\d+) "
+			+ "(?:\\{(.*)\\} )(?:Tournament (\\d+) (?:(Freeroll)|(\\S+?)\\+(\\S+?)(?: (USD|GBP))?) )?"
 			+ "(?:(Mixed \\S+|Triple Stud|8Game|HORSE) )?"
 			+ "(.+?) "
 			+ "(No Limit|Pot Limit|Limit) "
-			+ "(?:(?:Match Round (\\w+) )?(?:Level (\\w+)) )?" 
-			+ "(\\S+?)/(\\S+?)(?: (USD))?");
+			+ "(?:(?:Match Round (\\w+) )?(?:Level (\\w+)) )?"
+			+ "(\\S+?)/(\\S+?)(?: (USD|GBP))?");
 	/** hand pattern capturing group constants */
-	static final int zoom = 1, handid = 2, tournid = 3, freeroll = 4, tbuyin = 5, tcost = 6, tcur = 7, mix = 8, game = 9,
-			limit = 10, tround = 11, tlevel = 12, sb = 13, bb = 14, blindcur = 15;
+	static final int homegame = 1, zoom = 2, handid = 3, clubidname = 4, tournid = 5, freeroll = 6, tbuyin = 7, tcost = 8, tcur = 9, mix = 10, game = 11,
+			limit = 12, tround = 13, tlevel = 14, sb = 15, bb = 16, blindcur = 17;
 }

--- a/src/pet/hp/impl/PSParser.java
+++ b/src/pet/hp/impl/PSParser.java
@@ -35,8 +35,9 @@ public class PSParser extends Parser2 {
 	
 	@Override
 	public boolean isHistoryFile (String name) {
-		// TS - tournament summaries
-		return name.startsWith("HH") && name.endsWith(".txt");
+		// tournament summaries OR emailed hand histories
+		return name.startsWith("HH") && name.endsWith(".txt")
+				|| name.startsWith("PokerStars Hand History Request") &&  name.endsWith(".txt");
 	}
 	
 	/**
@@ -58,7 +59,7 @@ public class PSParser extends Parser2 {
 			line = line.substring(1);
 			println("skip bom");
 		}
-		
+
 		int i = 0;
 		line = line.trim();
 		println(">>> " + line);
@@ -205,7 +206,7 @@ public class PSParser extends Parser2 {
 			}
 			
 		} else {
-			fail("unknown line " + line);
+			println("unknown line " + line);
 		}
 		
 		return false;
@@ -328,7 +329,7 @@ public class PSParser extends Parser2 {
 			println("seat " + seat);
 		}
 	}
-	
+
 	/**
 	 * Parse the hand line starting with PokerStars
 	 */
@@ -347,7 +348,7 @@ public class PSParser extends Parser2 {
 		
 		Matcher m = PSHandRE.pat.matcher(handline);
 		assert_ (m.matches(), "match hand exp");
-		
+
 		game = new Game();
 		
 		// sub type - currently just zoom

--- a/src/pet/hp/impl/ParseUtil.java
+++ b/src/pet/hp/impl/ParseUtil.java
@@ -75,7 +75,7 @@ public class ParseUtil {
 		// $2
 		// $1.05
 		boolean dec = false;
-		if ("$€".indexOf(line.charAt(off)) >= 0) {
+		if ("$€£".indexOf(line.charAt(off)) >= 0) {
 			off++;
 			dec = true;
 		}
@@ -171,7 +171,7 @@ public class ParseUtil {
 	 */
 	static char parseCurrency(String line, int off) {
 		char c = line.charAt(off);
-		if ("$€".indexOf(c) >= 0) {
+		if ("$€£".indexOf(c) >= 0) {
 			return c;
 		} else if (c >= '0' && c <= '9') {
 			// could be tourn chips...

--- a/src/pet/hp/info/FollowThread.java
+++ b/src/pet/hp/info/FollowThread.java
@@ -164,6 +164,23 @@ public class FollowThread extends Thread {
 				long pos = 0;
 				String line;
 				while ((line = br.readLine()) != null) {
+
+					if (line.startsWith("Subject:")) {
+						// consume all lines until first "*********** #"
+						while ((line = br.readLine()) != null) {
+							if (line.startsWith("*********** #")){
+								line = br.readLine();
+								break;
+							}
+						}
+						if (line == null) {
+							break;
+						}
+					// emailed hand histories have numbered hand e.g. "*********** # 2 **************"
+					} else if (line.startsWith("*********** #")) {
+						continue;
+					}
+
 					boolean hand = parser.parseLine(line);
 					if (hand) {
 						pos = fis.getChannel().position();


### PR DESCRIPTION
There are a few things contained in this PR which might be better to split up.
Presented here for discussion.
PS. I'm not a java dev.

Added support for GBP is simple enough.

I only play home games on pokerstars so have not been able to verify the altered regex still works with  the other types.

email skipping was tested with thunderbird "save as" .txt but I have no clue what other email clients do so maybe don't include this part of the patch.

The change of fail("unknown line " + line); into a println is because the emails have a prologue about contacting support etc... and there seems no need to fail.

Nice tool.  Thanks to the dev.


